### PR TITLE
Darker color in text input bar

### DIFF
--- a/whatsapp/darkmode.css
+++ b/whatsapp/darkmode.css
@@ -1033,7 +1033,7 @@ html[dir='LTR'] .landing-header::after {
 }
 
 ._3FRCZ{
-  color: #eee !important;
+  color: #282d37 !important;
 }
 
 @keyframes pulse {


### PR DESCRIPTION
changed "_3FRCZ" reference color from #eee (light color) to #282d37 (dark color)
._3FRCZ{
color: #282d37 !important;

https://github.com/ducfilan/Dark-mode-Franz-Ferdi/issues/28