### PR TITLE
Fix a few Facebook Messenger issues

### DIFF
--- a/messenger/darkmode.css
+++ b/messenger/darkmode.css
@@ -345,8 +345,7 @@ body ._1sk6,
 body ._4gd0,
 body ._5pw9,
 body ._58ahm,
-body ._80cm,
-body ._3egs {
+body ._80cm {
     background: #222222 !important;
 }
 
@@ -942,4 +941,9 @@ body ._8sop:focus {
 
 .uiScrollableAreaGripper {
     background-color: #6d6d6d !important;
+}
+
+/* Replied to message */
+body ._3egs {
+    background-color: black !important;
 }

--- a/messenger/darkmode.css
+++ b/messenger/darkmode.css
@@ -952,3 +952,16 @@ body ._3egs {
 body ._4gd0 {
     background-color: black !important;
 }
+
+/* Code blocks
+
+These can be created in Facebook as in Github by typing:
+```
+code in here
+```
+*/
+._wu0 {
+    color: white;
+    background-color: #222222;
+    border: 1px solid #333333;
+}

--- a/messenger/darkmode.css
+++ b/messenger/darkmode.css
@@ -342,7 +342,6 @@ body ._59s7,
 body ._3s-4,
 body ._2y8_,
 body ._1sk6,
-body ._4gd0,
 body ._5pw9,
 body ._58ahm,
 body ._80cm {

--- a/messenger/darkmode.css
+++ b/messenger/darkmode.css
@@ -961,7 +961,7 @@ code in here
 ```
 */
 ._wu0 {
-    color: white;
-    background-color: #222222;
-    border: 1px solid #333333;
+    color: white !important;
+    background-color: #222222 !important;
+    border: 1px solid #333333 !important;
 }

--- a/messenger/darkmode.css
+++ b/messenger/darkmode.css
@@ -947,3 +947,8 @@ body ._8sop:focus {
 body ._3egs {
     background-color: black !important;
 }
+
+/* Typing indicator */
+body ._4gd0 {
+    background-color: black !important;
+}


### PR DESCRIPTION
Fixes #38, and another issue relating to code blocks.

Before:
<img width="488" alt="code-blocks-before" src="https://user-images.githubusercontent.com/10577181/92718270-e1916180-f361-11ea-84e7-71da77501fd6.png">

After:
<img width="319" alt="code-blocks-after" src="https://user-images.githubusercontent.com/10577181/92718274-e2c28e80-f361-11ea-9848-6f74ad9d60cf.png">

Not sure this is the best look, but I neither have access to a phone nor a Windows 10 computer I can test it with, to keep in sync with #37, but it's definitely better than the alternative.

Sorry for the messy commits, tried using Github's online UI which is pretty bad.