### PR TITLE
Corrected the Windows appdata path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 1. Copy the `darkmode.css` file to the corresponding `recipe` (service) folder. For example: below's `[service folder]` means `messenger` or `slack` etc.:
   * Mac: `~/Library/Application Support/Franz/recipes/[service folder]`
-  * Windows: `%appdata%/Franz/recipes/[service folder]`. Press `Windows`+`R` to open the `Run` dialog and paste this path, for example: `%appdata%/Franz/recipes/messenger`
+  * Windows: `%appdata%/Roaming/Franz/recipes/[service folder]`. Press `Windows`+`R` to open the `Run` dialog and paste this path, for example: `%appdata%/Roaming/Franz/recipes/messenger`
   * Linux: `~/.config/Franz/recipes/[service folder]`
 2. Reload Franz
 3. Open Franz's Settings (`Ctrl`+`,`) > Select `Your services` tab > Select the service that you want to change to dark mode and toggle the `Enable Dark Mode` setting


### PR DESCRIPTION
my franz installation which came via chocolatey creates the appdata folder in the `Roaming` folder. I guess thats common since I've never seen an appdata folder directly under `%appdata%/`.